### PR TITLE
Updates to readme to reduce new player confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ After installation be sure to DoomRPG settings reset (Options -> DoomRPG Otions 
 
 Use the following load order:
 
-1. [WadSmoosh](https://forum.zdoom.org/viewtopic.php?f=19&t=52757) and/or [The Sentinel's Lexicon - PvE mapset Compilaition](https://github.com/WNC12k/DoomRPG-Lexicon/releases) or another mapset;
+1. [WadSmoosh](https://forum.zdoom.org/viewtopic.php?f=19&t=52757) or [The Sentinel's Lexicon - PvE mapset Compilaition](https://github.com/WNC12k/DoomRPG-Lexicon/releases) or another mapset;
 2. [DoomRL Arsenal 1.1.5](https://forum.zdoom.org/viewtopic.php?f=43&t=37044) or [LegenDoom v2.8.3](https://forum.zdoom.org/viewtopic.php?t=51035);
 3. [DoomRL Monsters Beta 7.3](https://forum.zdoom.org/viewtopic.php?f=43&t=37044) or [Colourful Hell v0.99b](https://forum.zdoom.org/viewtopic.php?t=47980) or [Rampancy v2.0](https://forum.zdoom.org/viewtopic.php?f=43&t=67193) or [Dehacked Attack v4.0](https://forum.zdoom.org/viewtopic.php?f=43&t=72362) or [Pandemonia Monsters v2.2](https://forum.zdoom.org/viewtopic.php?t=60984);
 4. [DoomRL Arsenal Extended 1.1c](https://forum.zdoom.org/viewtopic.php?f=43&t=70549);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sumwunn Rebalance-Sync
 
-This is WNC12k's rebalance fork + my latest fixes and improvements (see commits). Text past the dashed line is original.
+This is WNC12k's rebalance fork + my latest fixes and improvements (see commits). Text past the dashed line is original (with updated versions and links).
 
 - Current Rebalance-Sync: v1.34 (Mar 8, 2024)
 
@@ -30,7 +30,7 @@ Enjoy!
 ## Installing (build)
 
 Below is the download link:
-1. [DoomRPG SE Rebalance Last Build (for GZDoom 4.10.0)](https://drive.google.com/drive/folders/1lbhGQVh_MXSTBQ-iCmuOIHOE31HREPUE?usp=sharing)
+1. [DoomRPG SE Rebalance Last Build (for GZDoom 4.12.2)](https://github.com/Sumwunn/DoomRPG/archive/refs/heads/rebalance-sync.zip)
 
 Installation Instructions:
 
@@ -41,7 +41,7 @@ Installation Instructions:
 
 ## Manual Installing
 
-- [GZDoom v4.10.0](https://github.com/coelckers/gzdoom/releases/download/g4.10.0/gzdoom-4-10-0-Windows-64bit.zip) is required to play this mod.
+- [GZDoom v4.12.2](https://github.com/ZDoom/gzdoom/releases/download/g4.12.2/gzdoom-4-12-2-Windows.zip) is required to play this mod.
 - LZDoom v3.83a or higher.
 - Delta Touch (Android) v4.6 or higher (includes the above versions or higher).
 
@@ -53,7 +53,7 @@ Use the following load order:
 
 1. [WadSmoosh](https://forum.zdoom.org/viewtopic.php?f=19&t=52757) or [The Sentinel's Lexicon - PvE mapset Compilaition](https://github.com/WNC12k/DoomRPG-Lexicon/releases) or another mapset;
 2. [DoomRL Arsenal 1.1.5](https://forum.zdoom.org/viewtopic.php?f=43&t=37044) or [LegenDoom v2.8.3](https://forum.zdoom.org/viewtopic.php?t=51035);
-3. [DoomRL Monsters Beta 7.3](https://forum.zdoom.org/viewtopic.php?f=43&t=37044) or [Colourful Hell v0.99b](https://forum.zdoom.org/viewtopic.php?t=47980) or [Rampancy v2.0](https://forum.zdoom.org/viewtopic.php?f=43&t=67193) or [Dehacked Attack v4.0](https://forum.zdoom.org/viewtopic.php?f=43&t=72362) or [Pandemonia Monsters v2.2](https://forum.zdoom.org/viewtopic.php?t=60984);
+3. [DoomRL Monsters Beta 7.3](https://forum.zdoom.org/viewtopic.php?f=43&t=37044) or [Colourful Hell v1.01](https://forum.zdoom.org/viewtopic.php?t=47980) or [Rampancy v2.0](https://forum.zdoom.org/viewtopic.php?f=43&t=67193) or [Dehacked Attack v4.0](https://forum.zdoom.org/viewtopic.php?f=43&t=72362) or [Pandemonia Monsters v2.2](https://forum.zdoom.org/viewtopic.php?t=60984);
 4. [DoomRL Arsenal Extended 1.1c](https://forum.zdoom.org/viewtopic.php?f=43&t=70549);
 5. [Corruption Cards 5.1c](https://forum.zdoom.org/viewtopic.php?t=67939);
 6. DoomRPG;
@@ -64,10 +64,10 @@ Use the following load order:
 - [DoomRL Arsenal - v1.1.5](https://forum.zdoom.org/viewtopic.php?f=43&t=37044);
 - [DoomRL Monsters Beta 7.3](https://forum.zdoom.org/viewtopic.php?f=43&t=37044);
 - [DoomRL Arsenal Extended - v1.1c](https://forum.zdoom.org/viewtopic.php?f=43&t=70549);
-- [Corruption Cards 5.1c](https://forum.zdoom.org/viewtopic.php?t=67939);
+- [Corruption Cards 5.5](https://forum.zdoom.org/viewtopic.php?t=67939);
 - [Rampancy v2.0](https://forum.zdoom.org/viewtopic.php?f=43&t=67193);
 - [LegenDoom v2.8.3](https://forum.zdoom.org/viewtopic.php?t=51035);
-- [Colourful Hell v0.99b](https://forum.zdoom.org/viewtopic.php?t=47980);
+- [Colourful Hell v1.01](https://forum.zdoom.org/viewtopic.php?t=47980);
 - [Dehacked Attack v4.0](https://forum.zdoom.org/viewtopic.php?f=43&t=72362);
 - [Pandemonia Monsters v2.2](https://forum.zdoom.org/viewtopic.php?t=60984);
 - Custom version of Jimmy's Jukebox Instant Randomizer has been included which allows DRPG's map events and Outpost music to play.


### PR DESCRIPTION
Updated links to GZDoom version (tested 4.12.2 and it's worked great over the course of 20+ hours of play) and mod version numbers. Removed the Dropbox link and changed it to download the zip of the latest version of rebalance-sync and clarified that the original readme has some of these changes.

The reason I feel this needs to be changed is that some new players in the DRPG Discord channel who are now finding rebalance-sync are getting confused and doing things like loading map packs together, using older GZDoom versions with bugs, using the Dropbox link, asking about using older versions of mods, etc... So it would be nice if the README was more up to date to reduce confusion.